### PR TITLE
Fix for Warning: random is deprecated [Deprecated]

### DIFF
--- a/examples/opengl/main_mobile.nim
+++ b/examples/opengl/main_mobile.nim
@@ -4,7 +4,7 @@ import wiishpkg/sdlapp
 import logging
 import opengl
 
-import random
+from random import randomize, rand
 randomize()
 var
   r = 45/255.0
@@ -32,9 +32,9 @@ app.sdl_event.handle(evt):
   debug "Event"
   case evt.kind
   of MouseButtonDown:
-    r = random(255).toFloat / 255.0
-    g = random(255).toFloat / 255.0
-    b = random(255).toFloat / 255.0
+    r = rand(255).toFloat / 255.0
+    g = rand(255).toFloat / 255.0
+    b = rand(255).toFloat / 255.0
   else:
     discard
 


### PR DESCRIPTION
Deprecated since version 0.18.0. Use [rand](https://nim-lang.org/docs/random.html#random) instead. 