### PR TITLE
Fix for "Android error libsdl2.so failed to load"

### DIFF
--- a/wiishpkg/building/data/SDL/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/wiishpkg/building/data/SDL/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -142,6 +142,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
      */
     protected String[] getLibraries() {
         return new String[] {
+            "hidapi",
             "SDL2",
             // "SDL2_image",
             // "SDL2_mixer",


### PR DESCRIPTION
With this fix the app works on older android devices.
More information:
https://discourse.libsdl.org/t/android-error-libsdl2-so-failed-to-load/25680