### PR TITLE
Exception message: SSL support is not available. Cannot connect over …

### DIFF
--- a/wiishpkg/building/build.nim
+++ b/wiishpkg/building/build.nim
@@ -83,6 +83,7 @@ proc doDesktopRun*(directory:string = ".") =
   # if defined(linux):
   #   args.add("--dynlibOverride:SDL2")
   args.add("-d:wiishDev")
+  args.add("-d:ssl")
   args.add("--threads:on")
   args.add("-r")
   args.add(src_file)


### PR DESCRIPTION
…SSL. Compile with -d:ssl to enable.

Please add -d:ssl to enable ssl requests.
Thank you