### PR TITLE
Pinned argparse version so we can still install.

### DIFF
--- a/wiish.nimble
+++ b/wiish.nimble
@@ -13,7 +13,7 @@ bin           = @["wiish"]
 
 requires "nim >= 0.19.0"
 requires "parsetoml >= 0.3.2"
-requires "argparse >= 0.7.1" # "https://github.com/iffy/nim-argparse.git"
+requires "argparse == 0.10.1" # "https://github.com/iffy/nim-argparse.git"
 # requires "https://github.com/mjendrusch/objc.git"
 requires "jnim >= 0.5"
 


### PR DESCRIPTION
Due to updates in argparse, wiish was having trouble installing.
This commit just pins the argparse version for the short term so that
it's still usable while revamp is in progress.

```
C:\Users\bubth\Development\wiish [master ≡ +0 ~1 -0 ~]> nimble install
   Warning: Package 'wiish' has an incorrect structure. It should contain a single directory hierarchy for source files, named 'wiishpkg', but file 'main_mobile.nim' is in a directory named 'examples\mobileutil' instead. This will be an error in the future.
      Hint: If 'examples\mobileutil' contains source files for building 'wiish', rename it to 'wiishpkg'. Otherwise, prevent its installation by adding `skipDirs = @["examples\mobileutil"]` to the .nimble file.
  Verifying dependencies for wiish@0.1.0
      Info: Dependency on parsetoml@>= 0.3.2 already satisfied
  Verifying dependencies for parsetoml@0.5.0
      Info: Dependency on argparse@0.10.1 already satisfied
  Verifying dependencies for argparse@0.10.1
      Info: Dependency on jnim@>= 0.5 already satisfied
  Verifying dependencies for jnim@0.5.1
      Info: Dependency on opengl@>= 1.2.1 already satisfied
      Info: Dependency on webview@any version already satisfied
  Verifying dependencies for webview@0.1.0
      Info: Dependency on https://github.com/Vladar4/sdl2_nim.git@#master already satisfied
   Warning: Package 'sdl2_nim' has an incorrect structure. It should contain a single directory hierarchy for source files, named 'sdl2_nim', but file 'atomics.nim' is in a directory named 'sdl2\private' instead. This will be an error in the future.
      Hint: If 'sdl2\private' contains source files for building 'sdl2_nim', rename it to 'sdl2_nim'. Otherwise, prevent its installation by adding `skipDirs = @["sdl2\private"]` to the .nimble file.
  Verifying dependencies for sdl2_nim@#master
      Info: Dependency on https://github.com/yglukhov/darwin@any version already satisfied
  Verifying dependencies for darwin@0.1.0
 Installing wiish@0.1.0
   Building wiish/wiish.exe using c backend
C:\Users\bubth\Development\wiish\wiish.nim(8, 8) Warning: import os.nim instead; ospaths is deprecated [Deprecated]
C:\Users\bubth\Development\wiish\wiishpkg\building\buildutil.nim(62, 13) Warning: use dirExists; existsDir is deprecated [Deprecated]
Pinned argparse version so we can still install.
C:\Users\bubth\Development\wiish\wiishpkg\building\build_macos.nim(2, 8) Warning: imported and not used: 'osproc' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_macos.nim(5, 8) Warning: imported and not used: 'posix' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_ios.nim(13, 8) Warning: imported and not used: 'xmlparser' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_ios.nim(11, 8) Warning: imported and not used: 'sequtils' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_windows.nim(3, 8) Warning: import os.nim instead; ospaths is deprecated [Deprecated]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_windows.nim(1, 8) Warning: imported and not used: 'os' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_windows.nim(2, 8) Warning: imported and not used: 'osproc' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_windows.nim(5, 8) Warning: imported and not used: 'parsetoml' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_windows.nim(4, 8) Warning: imported and not used: 'strformat' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_linux.nim(1, 8) Warning: imported and not used: 'os' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_linux.nim(2, 8) Warning: imported and not used: 'osproc' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_linux.nim(3, 8) Warning: imported and not used: 'strformat' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_linux.nim(4, 8) Warning: imported and not used: 'posix' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_linux.nim(5, 8) Warning: imported and not used: 'parsetoml' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_linux.nim(8, 8) Warning: imported and not used: 'buildutil' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_android.nim(53, 23) Warning: use dirExists; existsDir is deprecated [Deprecated]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_android.nim(75, 23) Warning: use dirExists; existsDir is deprecated [Deprecated]
C:\Users\bubth\Development\wiish\wiishpkg\building\build_android.nim(8, 8) Warning: imported and not used: 'posix' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\build.nim(2, 8) Warning: imported and not used: 'osproc' [UnusedImport]
C:\Users\bubth\Development\wiish\wiishpkg\building\doctor.nim(1, 8) Warning: imported and not used: 'os' [UnusedImport]
C:\Users\bubth\Development\wiish\wiish.nim(2, 8) Warning: imported and not used: 'strformat' [UnusedImport]
C:\Users\bubth\Development\wiish\wiish.nim(16, 8) Warning: imported and not used: 'sugar' [UnusedImport]
Prompt: wiish@0.1.0 already exists. Overwrite? [y/N]
Answer: y
Success: wiish installed successfully.
C:\Users\bubth\Development\wiish [master ≡ +0 ~1 -0 | +1 ~0 -0 !]> 
```